### PR TITLE
ci: expand codecov uploads; add create-integration-label workflow; badge follow-up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,11 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
+          files: |
+            coverage.xml
+            coverage/coverage.xml
+            coverage/**/*.xml
+            coverage/**/coverage-*.xml
           flags: unittests
           fail_ci_if_error: false
 

--- a/.github/workflows/create-integration-label.yml
+++ b/.github/workflows/create-integration-label.yml
@@ -1,0 +1,34 @@
+name: Create integration label
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Ensure jq is available
+        run: sudo apt-get update && sudo apt-get install -y jq curl || true
+
+      - name: Create label via GitHub API
+        env:
+          GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          LABEL_NAME='run-integration'
+          COLOR='0e8a16'
+          BODY='Apply to a PR to trigger integration tests in CI.'
+          echo "Creating label $LABEL_NAME in $REPO"
+          API_URL="https://api.github.com/repos/$REPO/labels"
+          PAYLOAD=$(jq -n --arg name "$LABEL_NAME" --arg color "$COLOR" --arg desc "$BODY" '{name:$name,color:$color,description:$desc}')
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H "Authorization: token $GH_TOKEN" -H "Accept: application/vnd.github.v3+json" $API_URL -d "$PAYLOAD")
+          if [ "$HTTP_STATUS" = "201" ]; then
+            echo "Label created"
+          elif [ "$HTTP_STATUS" = "422" ]; then
+            echo "Label already exists (or validation error)."
+          else
+            echo "Unexpected response: $HTTP_STATUS"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # CollTech-AGI v20.7
 
-[![Unit Tests](https://github.com/NC-ADC84/colltech-agi/actions/workflows/ci.yml/badge.svg)](https://github.com/NC-ADC84/colltech-agi/actions/workflows/ci.yml) [![Codecov](https://img.shields.io/codecov/c/github/NC-ADC84/colltech-agi?logo=codecov)](https://codecov.io/gh/NC-ADC84/colltech-agi)
+[![Unit Tests](https://github.com/NC-ADC84/colltech-agi/actions/workflows/ci.yml/badge.svg)](https://github.com/NC-ADC84/colltech-agi/actions/workflows/ci.yml) [![Codecov](https://img.shields.io/badge/coverage-unknown-lightgrey.svg)](https://codecov.io/gh/NC-ADC84/colltech-agi)
+
+<!-- NOTE: Once the first Codecov upload completes I will open a follow-up PR to replace the Codecov badge URL with the exact repository slug so the badge reports live coverage. -->
 
 ## Consciousness-Based AGI with Catch System Integration
 


### PR DESCRIPTION
Summary:
- Expanded codecov uploads to publish multiple coverage patterns
- Added workflow to create the 'run-integration' label (manual run, requires GH_ADMIN_TOKEN secret)
- Left a follow-up note in README to replace the Codecov badge after first upload

Notes:
- To enable Codecov uploads in CI add secret CODECOV_TOKEN (private repos).
- To run the create-label workflow add secret GH_ADMIN_TOKEN (a PAT with repo scope) OR create the label in UI.